### PR TITLE
Show intermediate steps while working

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -9,6 +9,7 @@ end
 
 require_relative "src/agent"
 
+Langchain.logger.level = :info
 llm = Langchain::LLM::Anthropic.new(api_key: ENV.fetch("ANTHROPIC_API_KEY"),
                                     default_options: { chat_model: "claude-3-7-sonnet-latest" })
 

--- a/src/agent.rb
+++ b/src/agent.rb
@@ -47,7 +47,7 @@ class Agent
   end
 
   def evaluate_input(user_input)
-    @assistant.add_message_and_run(content: user_input)
+    @assistant.add_message_and_run!(content: user_input)
   end
 
   def print_result

--- a/src/agent.rb
+++ b/src/agent.rb
@@ -11,12 +11,9 @@ class Agent
     @assistant = Langchain::Assistant.new(
       llm: llm,
       instructions: "You are a helpful coding assistant with file system access.",
-      tools: [
-        Tools::ReadFile.new,
-        Tools::ListFiles.new,
-        Tools::EditFile.new,
-        Tools::RunShellCommand.new
-      ]
+      tools: standard_tools,
+      add_message_callback: method(:add_message_callback).to_proc,
+      tool_execution_callback: method(:tool_execution_callback).to_proc
     )
   end
 
@@ -33,6 +30,30 @@ class Agent
   end
 
   private
+
+  def add_message_callback(message)
+    case message.standard_role
+    when :user, :tool
+      # skip
+    when :llm
+      puts message.content if message.tool_calls.any?
+    else
+      raise NotImplementedError
+    end
+  end
+
+  def tool_execution_callback(_tool_call_id, tool_name, method_name, tool_arguments)
+    puts "** executing #{tool_name}##{method_name} with #{tool_arguments.inspect}"
+  end
+
+  def standard_tools
+    [
+      Tools::ReadFile.new,
+      Tools::ListFiles.new,
+      Tools::EditFile.new,
+      Tools::RunShellCommand.new
+    ]
+  end
 
   def instruct_user
     puts "Chat with the agent. Type 'exit' to ... well, exit"

--- a/src/agent.rb
+++ b/src/agent.rb
@@ -40,7 +40,7 @@ class Agent
 
   def read_user_input
     print "> "
-    user_input = gets.chomp
+    user_input = gets&.chomp or return false
     return false if user_input.strip.downcase == "exit"
 
     user_input


### PR DESCRIPTION
- Make the assistant actually execute the chosen tools
- Exit gracefully when user tries to exit using Ctrl-D
- Silence DEBUG messages from Langchain
- Show intermediate llm messages and tool calls
